### PR TITLE
Fix circular argument reference

### DIFF
--- a/lib/keeper.rb
+++ b/lib/keeper.rb
@@ -33,11 +33,11 @@ module Keeper
     end
 
     private
-    def select_in collection, key: key, id: id
+    def select_in collection, key: nil, id: nil
       collection.select{|o| o[key] == id }
     end
 
-    def find_in collection, key: key, id: id
+    def find_in collection, key: nil, id: nil
       collection.find{|o| o[key] == id }
     end
 


### PR DESCRIPTION
@Fantaz1 

In Ruby 2.2 these now throw a warning:

/Users/jordan/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/bundler/gems/keeper-a7bdab2172c9/lib/keeper.rb:36: warning: circular argument reference - key
/Users/jordan/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/bundler/gems/keeper-a7bdab2172c9/lib/keeper.rb:36: warning: circular argument reference - id
/Users/jordan/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/bundler/gems/keeper-a7bdab2172c9/lib/keeper.rb:40: warning: circular argument reference - key
/Users/jordan/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/bundler/gems/keeper-a7bdab2172c9/lib/keeper.rb:40: warning: circular argument reference - id
