### PR TITLE
Improving debugability - Add name to anon modules.

### DIFF
--- a/keeper.gemspec
+++ b/keeper.gemspec
@@ -23,6 +23,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency 'activesupport', "4.2.10"
+
   spec.add_development_dependency "bundler", "~> 1.8"
   spec.add_development_dependency "rake", "~> 10.0"
 end

--- a/lib/keeper.rb
+++ b/lib/keeper.rb
@@ -1,9 +1,11 @@
 require "keeper/version"
+require "active_support/inflector"
 
 module Keeper
   class Base
     def self.store key, find: :id, select: :id, &block
       mod = Module.new
+      const_set("#{key.to_s.upcase}_KEEPER_STORE", mod)
       mod.send(:define_method, "#{key}_content", block)
       include mod
 

--- a/lib/keeper/version.rb
+++ b/lib/keeper/version.rb
@@ -1,3 +1,3 @@
 module Keeper
-  VERSION = "0.1.3"
+  VERSION = "0.2.0"
 end

--- a/spec/keeper_spec.rb
+++ b/spec/keeper_spec.rb
@@ -1,68 +1,30 @@
 require 'spec_helper'
 
 describe Keeper do
-  class Post
-    attr_accessor :title, :id
-    attr_accessor :coments
-
-    def initialize id, title
-
-    end
-  end
-
-  class Address
-
-  end
-
-  class User
-    def posts
-      [
-        {id: 1, title: 'FirstTitle'},
-        {id: 2, title: 'SecondTitle'},
-        {id: 3, title: 'ThirdTitle'}
-      ]
-    end
-  end
-
-  class MyKeeper << Keeper::Base
-    def initialize user
-      @user = user
-    end
-
-    store :posts do
-
-    end
-
-    store :comments do
-
-    end
-
-    store :addresses do
-
-    end
-  end
-
   it 'has a version number' do
     expect(Keeper::VERSION).not_to be nil
   end
 
-  context "#getter" do
+  context 'debuggability' do
+    class Base < Keeper::Base
+      store(:base) { [1, 2, 3] }
+    end
 
-  end
+    class Child < Base
+      store(:child) { [4, 5, 6] }
+    end
 
-  context "#setter" do
-
-  end
-
-  context "find an array of objects in collection" do
-
-  end
-
-  context 'find a object in collection' do
-
-  end
-
-  context 'array of IDs' do
-
+    it 'puts stores in correct order' do
+      expect(Child.ancestors).to include(
+        Child,
+        Child::CHILD_KEEPER_STORE,
+        Base,
+        Base::BASE_KEEPER_STORE,
+        Keeper::Base,
+        Object,
+        Kernel,
+        BasicObject
+      )
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,2 @@
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+$LOAD_PATH.unshift File.expand_path('lib', __dir__)
 require 'keeper'


### PR DESCRIPTION
Hi @zevgeniy @jordanfbrown ,

Over the weekend I was playing with Keeper and I was having a hard time knowing from which module was responsible for what. This PR just adds a name to each store when is included in inherited class.

Also, I'm assuming, that semver is being used for this gem, so I updated to version `0.2.0`.

* Adding 'activesupport' as a direct dependency
* Fixing specs
* Adding name to anonymous module.